### PR TITLE
"Removeoulier" enable scaling to bitdepth

### DIFF
--- a/plugins/correctspillovermeasurement.py
+++ b/plugins/correctspillovermeasurement.py
@@ -13,7 +13,7 @@ import scipy.optimize as spo
 import cellprofiler.image  as cpi
 import cellprofiler.module as cpm
 import cellprofiler.setting as cps
-import cellprofiler.measurements as cpmeas
+import cellprofiler.measurement as cpmeas
 
 
 SETTINGS_PER_IMAGE = 5

--- a/plugins/smoothmultichannel.py
+++ b/plugins/smoothmultichannel.py
@@ -45,13 +45,13 @@ GAUSSIAN_FILTER = 'Gaussian Filter'
 SMOOTH_KEEPING_EDGES = 'Smooth Keeping Edges'
 CIRCULAR_AVERAGE_FILTER = 'Circular Average Filter'
 SM_TO_AVERAGE = "Smooth to Average"
-CLIP_HOT_PIXELS = "Clip hot pixels"
+CLIP_HOT_PIXELS = "Remove single hot pixels"
 
 
 class SmoothMultichannel(cpm.Module):
     module_name = 'SmoothMultichannel'
     category = "Image Processing"
-    variable_revision_number = 3
+    variable_revision_number = 5
 
     def create_settings(self):
         self.image_name = cps.ImageNameSubscriber('Select the input image', cps.NONE, doc="""Select the image to be smoothed.""")
@@ -210,8 +210,8 @@ example, if one wants to set a threshold of 100 counts, a value of either
                          module_name, from_matlab):
         if variable_revision_number < 2:
             setting_values += [3 , 20]  # hp_filter_size, hp_threshold
-        if variable_revision_number < 3:
-            setting_values.append(False)  # scale_hp_threshold
+        if variable_revision_number < 4:
+            setting_values.append(cps.NO)  # scale_hp_threshold 
         return setting_values, variable_revision_number, from_matlab
 
     def visible_settings(self):

--- a/plugins/smoothmultichannel.py
+++ b/plugins/smoothmultichannel.py
@@ -49,7 +49,7 @@ CLIP_HOT_PIXELS = "Remove single hot pixels"
 
 
 class SmoothMultichannel(cpm.Module):
-    module_name = 'SmoothMultichannel'
+    module_name = 'Smooth Multichannel'
     category = "Image Processing"
     variable_revision_number = 5
 

--- a/plugins/smoothmultichannel.py
+++ b/plugins/smoothmultichannel.py
@@ -245,7 +245,7 @@ example, if one wants to set a threshold of 100 counts, a value of either
             else:
                 output_pixels = image.pixel_data.copy()
                 for channel in range(image.pixel_data.shape[2]):
-                    output_pixels[:, :, i] = self.run_grayscale(image.pixel_data[:, :, i], image)
+                    output_pixels[:, :, channel] = self.run_grayscale(image.pixel_data[:, :, channel], image)
         else:
             if self.smoothing_method.value == CLIP_HOT_PIXELS:
                 # TODO support masks

--- a/plugins/smoothmultichannel.py
+++ b/plugins/smoothmultichannel.py
@@ -211,7 +211,7 @@ example, if one wants to set a threshold of 100 counts, a value of either
         if variable_revision_number < 2:
             setting_values += [3 , 20]  # hp_filter_size, hp_threshold
         if variable_revision_number < 4:
-            setting_values.append(cps.NO)  # scale_hp_threshold 
+            setting_values.append(cps.NO)  # scale_hp_threshold
         return setting_values, variable_revision_number, from_matlab
 
     def visible_settings(self):
@@ -245,21 +245,20 @@ example, if one wants to set a threshold of 100 counts, a value of either
             else:
                 output_pixels = image.pixel_data.copy()
                 for channel in range(image.pixel_data.shape[2]):
-                    output_pixels[:, :, i] = self.run_grayscale(image.pixel_data[:, :, i])
+                    output_pixels[:, :, i] = self.run_grayscale(image.pixel_data[:, :, i], image)
         else:
             if self.smoothing_method.value == CLIP_HOT_PIXELS:
                 # TODO support masks
                 hp_filter_shape = (self.hp_filter_size.value, self.hp_filter_size.value)
                 output_pixels = SmoothMultichannel.clip_hot_pixels(image.pixel_data, hp_filter_shape, hp_threshold)
             else:
-                output_pixels = self.run_grayscale(image.pixel_data)
+                output_pixels = self.run_grayscale(image.pixel_data, image)
         output_image = cpi.Image(output_pixels, parent_image=image)
         workspace.image_set.add(self.filtered_image_name.value, output_image)
         workspace.display_data.pixel_data = image.pixel_data
         workspace.display_data.output_pixels = output_pixels
 
-    def run_grayscale(self, image):
-        pixel_data = image.pixel_data
+    def run_grayscale(self, pixel_data, image):
         if self.wants_automatic_object_size.value:
             object_size = min(30, max(1, np.mean(pixel_data.shape) / 40))
         else:

--- a/plugins/smoothmultichannel.py
+++ b/plugins/smoothmultichannel.py
@@ -311,7 +311,7 @@ class SmoothMultichannel(cpm.Module):
         mask[int((radius-1)/2),int((radius-1)/2)] = 0
 
         if mode == 'max':
-            img_agg = ndi.generic_filter(img, np.max, footprint=mask)
+            img_agg = ndi.filters.maximum_filter(img, footprint=mask)
         elif mode == 'median':
             img_agg = ndi.generic_filter(img, np.median, footprint=mask)
         else:

--- a/plugins/smoothmultichannel.py
+++ b/plugins/smoothmultichannel.py
@@ -1,9 +1,29 @@
-'''<b>Smooth</b> smooths (i.e., blurs) images.
-<hr>
+# coding=utf-8
+
+"""
+SmoothMultichannel
+======
+
+**SmoothMultichannel** smooths (i.e., blurs) images.
+
 This module allows you to smooth (blur) images, which can be helpful to
-remove artifacts of a particular size.
-Note that smoothing can be a time-consuming process.
-'''
+remove small artifacts. Note that smoothing can be a time-consuming process
+and that all channels of the image are smoothed individually.
+
+|
+
+============ ============ ===============
+Supports 2D? Supports 3D? Respects masks?
+============ ============ ===============
+YES          NO           YES
+============ ============ ===============
+
+See also
+^^^^^^^^
+
+See also **Smooth** and several related modules in the *Advanced* category
+(e.g., **MedianFilter** and **GaussianFilter**).
+"""
 
 import numpy as np
 import scipy.ndimage as scind
@@ -11,15 +31,13 @@ from centrosome.filter import median_filter, bilateral_filter, circular_average_
 from centrosome.smooth import circular_gaussian_kernel
 from centrosome.smooth import fit_polynomial
 from centrosome.smooth import smooth_with_function_and_mask
+import skimage.restoration
 
 import cellprofiler.image as cpi
 import cellprofiler.module as cpm
 import cellprofiler.setting as cps
+from cellprofiler.modules._help import HELP_ON_MEASURING_DISTANCES, HELP_ON_PIXEL_INTENSITIES
 from cellprofiler.setting import YES, NO
-
-from matplotlib.widgets import Slider, Button, RadioButtons
-
-from scipy import ndimage as ndi
 
 FIT_POLYNOMIAL = 'Fit Polynomial'
 MEDIAN_FILTER = 'Median Filter'
@@ -27,147 +45,179 @@ GAUSSIAN_FILTER = 'Gaussian Filter'
 SMOOTH_KEEPING_EDGES = 'Smooth Keeping Edges'
 CIRCULAR_AVERAGE_FILTER = 'Circular Average Filter'
 SM_TO_AVERAGE = "Smooth to Average"
-REMOVE_OUTLIER = 'Remove single hot pixels'
+CLIP_HOT_PIXELS = "Clip hot pixels"
 
-NOTDEFINEDYET = 'Helptext Not Defined Yet'
-HELP_ON_MEASURING_DISTANCES = NOTDEFINEDYET
-HELP_ON_PIXEL_INTENSITIES = NOTDEFINEDYET
 
 class SmoothMultichannel(cpm.Module):
-    module_name = 'Smooth Multichannel'
+    module_name = 'SmoothMultichannel'
     category = "Image Processing"
-    variable_revision_number = 4
+    variable_revision_number = 3
 
     def create_settings(self):
-        self.image_name = cps.ImageNameSubscriber('Select the input image', cps.NONE)
+        self.image_name = cps.ImageNameSubscriber('Select the input image', cps.NONE, doc="""Select the image to be smoothed.""")
 
-        self.filtered_image_name = cps.ImageNameProvider('Name the output image', 'FilteredImage')
+        self.filtered_image_name = cps.ImageNameProvider('Name the output image', 'FilteredImage', doc="""Enter a name for the resulting image.""")
 
         self.smoothing_method = cps.Choice(
                 'Select smoothing method',
-                [FIT_POLYNOMIAL, GAUSSIAN_FILTER, MEDIAN_FILTER, SMOOTH_KEEPING_EDGES, CIRCULAR_AVERAGE_FILTER,
-                 SM_TO_AVERAGE, REMOVE_OUTLIER], doc="""
-            This module smooths images using one of several filters.
-            Fitting a polynomial
-            is fastest but does not allow a very tight fit compared to the other methods:
-            <ul>
-            <li><i>%(FIT_POLYNOMIAL)s:</i> This method treats the intensity of the image pixels
-            as a polynomial function of the x and y position of
-            each pixel. It fits the intensity to the polynomial,
-            <i>A x<sup>2</sup> + B y<sup>2</sup> + C xy + D x + E y + F</i>.
-            This will produce a smoothed image with a single peak or trough of intensity
-            that tapers off elsewhere in the image. For many microscopy images (where
-            the illumination of the lamp is brightest in the center of field of view),
-            this method will produce an image with a bright central region and dimmer
-            edges. But, in some cases the peak/trough of the polynomial may actually
-            occur outside of the image itself.</li>
-            <li><i>%(GAUSSIAN_FILTER)s:</i> This method convolves the image with a Gaussian whose
-            full width at half maximum is the artifact diameter entered.
-            Its effect is to blur and obscure features
-            smaller than the artifact diameter and spread bright or
-            dim features larger than the artifact diameter.</li>
-            <li><i>%(MEDIAN_FILTER)s:</i> This method finds the median pixel value within the
-            artifact diameter you specify. It removes bright or dim features that are much smaller
-            than the artifact diameter.</li>
-            <li><i>%(SMOOTH_KEEPING_EDGES)s:</i> This method uses a bilateral filter which
-            limits Gaussian smoothing across an edge while
-            applying smoothing perpendicular to an edge. The effect
-            is to respect edges in an image while smoothing other
-            features. <i>%(SMOOTH_KEEPING_EDGES)s</i> will filter an image with reasonable
-            speed for artifact diameters greater than 10 and for
-            intensity differences greater than 0.1. The algorithm
-            will consume more memory and operate more slowly as
-            you lower these numbers.</li>
-            <li><i>%(CIRCULAR_AVERAGE_FILTER)s:</i> This method convolves the image with
-            a uniform circular averaging filter whose size is the artifact diameter entered. This filter is
-            useful for re-creating an out-of-focus blur to an image.</li>
-            <li><i>%(SM_TO_AVERAGE)s:</i> Creates a flat, smooth image where every pixel
-            of the image equals the average value of the original image.</li>
-            <li><i>%(REMOVE_OUTLIER)s:</i> Remove single hot pixels</li>
-            </ul>""" % globals())
+                [CLIP_HOT_PIXELS, FIT_POLYNOMIAL, GAUSSIAN_FILTER, MEDIAN_FILTER, SMOOTH_KEEPING_EDGES,
+                 CIRCULAR_AVERAGE_FILTER, SM_TO_AVERAGE], doc="""\
+This module smooths images using one of several filters. Fitting a
+polynomial is fastest but does not allow a very tight fit compared to
+the other methods:
+
+-  *%(FIT_POLYNOMIAL)s:* This method is fastest but does not allow
+   a very tight “fit” compared to the other methods. Thus, it will usually be less
+   accurate. The method treats the intensity of the image
+   pixels as a polynomial function of the x and y position of each
+   pixel. It fits the intensity to the polynomial, *A x* :sup:`2` *+ B
+   y* :sup:`2` *+ C xy + D x + E y + F*. This will produce a smoothed
+   image with a single peak or trough of intensity that tapers off
+   elsewhere in the image. For many microscopy images (where the
+   illumination of the lamp is brightest in the center of field of
+   view), this method will produce an image with a bright central region
+   and dimmer edges. But, in some cases the peak/trough of the
+   polynomial may actually occur outside of the image itself.
+-  *%(GAUSSIAN_FILTER)s:* This method convolves the image with a
+   Gaussian whose full width at half maximum is the artifact diameter
+   entered. Its effect is to blur and obscure features smaller than the
+   specified diameter and spread bright or dim features larger than the
+   specified diameter.
+-  *%(MEDIAN_FILTER)s:* This method finds the median pixel value within
+   the diameter you specify. It removes bright or dim features
+   that are significantly smaller than the specified diameter.
+-  *%(SMOOTH_KEEPING_EDGES)s:* This method uses a bilateral filter
+   which limits Gaussian smoothing across an edge while applying
+   smoothing perpendicular to an edge. The effect is to respect edges in
+   an image while smoothing other features. *%(SMOOTH_KEEPING_EDGES)s*
+   will filter an image with reasonable speed for artifact diameters
+   greater than 10 and for intensity differences greater than 0.1. The
+   algorithm will consume more memory and operate more slowly as you
+   lower these numbers.
+-  *%(CIRCULAR_AVERAGE_FILTER)s:* This method convolves the image with
+   a uniform circular averaging filter whose size is the artifact
+   diameter entered. This filter is useful for re-creating an
+   out-of-focus blur to an image.
+-  *%(SM_TO_AVERAGE)s:* Creates a flat, smooth image where every pixel
+   of the image equals the average value of the original image.
+-  *%(CLIP_HOT_PIXELS)s:* Clips hot pixels to the maximum local neighbor
+   intensity. Hot pixels are identified by thresholding on the difference
+   between the pixel intensity and it's maximum local neighbor intensity.
+
+*Note, when deciding between %(MEDIAN_FILTER)s and %(GAUSSIAN_FILTER)s
+we typically recommend
+%(MEDIAN_FILTER)s over %(GAUSSIAN_FILTER)s because the
+median is less sensitive to outliers, although the results are also
+slightly less smooth and the fact that images are in the range of 0
+to 1 means that outliers typically will not dominate too strongly
+anyway.*
+""" % globals())
 
         self.wants_automatic_object_size = cps.Binary(
-                'Calculate artifact diameter automatically?', True, doc="""
-            <i>(Used only if "%(GAUSSIAN_FILTER)s", "%(MEDIAN_FILTER)s", "%(SMOOTH_KEEPING_EDGES)s",
-            "%(CIRCULAR_AVERAGE_FILTER)s" is selected)</i><br>
-            Select <i>%(YES)s</i> to choose an artifact diameter based on
-            the size of the image. The minimum size it will choose is 30 pixels,
-            otherwise the size is 1/40 of the size of the image.
-            <p>Select <i>%(YES)s</i> to manually enter an artifact diameter.</p>""" % globals())
+                'Calculate artifact diameter automatically?', True, doc="""\
+*(Used only if “%(GAUSSIAN_FILTER)s”, “%(MEDIAN_FILTER)s”, “%(SMOOTH_KEEPING_EDGES)s” or “%(CIRCULAR_AVERAGE_FILTER)s” is selected)*
+
+Select *%(YES)s* to choose an artifact diameter based on the size of
+the image. The minimum size it will choose is 30 pixels, otherwise the
+size is 1/40 of the size of the image.
+
+Select *%(NO)s* to manually enter an artifact diameter.
+""" % globals())
 
         self.object_size = cps.Float(
-                'Typical artifact diameter', 16.0, doc="""
-            <i>(Used only if choosing the artifact diameter automatically is set to "%(NO)s")</i><br>
-            Enter the approximate diameter (in pixels) of the features to be blurred by
-            the smoothing algorithm. This value is used to calculate the size of
-            the spatial filter. %(HELP_ON_MEASURING_DISTANCES)s
-            For most smoothing methods, selecting a
-            diameter over ~50 will take substantial amounts of time to process.""" % globals())
+                'Typical artifact diameter', 16.0, doc="""\
+*(Used only if choosing the artifact diameter automatically is set to
+“%(NO)s”)*
+
+Enter the approximate diameter (in pixels) of the features to be blurred
+by the smoothing algorithm. This value is used to calculate the size of
+the spatial filter. %(HELP_ON_MEASURING_DISTANCES)s For most
+smoothing methods, selecting a diameter over ~50 will take substantial
+amounts of time to process.
+""" % globals())
 
         self.sigma_range = cps.Float(
-                'Edge intensity difference', 0.1, doc="""
-            <i>(Used only if "%(SMOOTH_KEEPING_EDGES)s" is selected)</i><br>
-            Enter the intensity step (which indicates an edge in an image) that you want to preserve.
-            Edges are locations where the intensity changes precipitously, so this
-            setting is used to adjust the rough magnitude of these changes. A lower
-            number will preserve weaker edges. A higher number will preserve only stronger edges.
-            Values should be between zero and one. %(HELP_ON_PIXEL_INTENSITIES)s""" % globals())
+                'Edge intensity difference', 0.1, doc="""\
+*(Used only if “%(SMOOTH_KEEPING_EDGES)s” is selected)*
+
+Enter the intensity step (which indicates an edge in an image) that you
+want to preserve. Edges are locations where the intensity changes
+precipitously, so this setting is used to adjust the rough magnitude of
+these changes. A lower number will preserve weaker edges. A higher
+number will preserve only stronger edges. Values should be between zero
+and one. %(HELP_ON_PIXEL_INTENSITIES)s
+""" % globals())
 
         self.clip = cps.Binary(
-                'Clip intensities to 0 and 1?', True, doc="""
-            <i>(Used only if %(FIT_POLYNOMIAL)s is selected)</i><br>
-            The <i>%(FIT_POLYNOMIAL)s</i> method is the only smoothing option that can yield
-            an output image whose values are outside of the values of the
-            input image. This setting controls whether to limit the image
-            intensity to the 0 - 1 range used by CellProfiler.
-            <p>Select <i>%(YES)s</i> to set all output image pixels less than zero to zero
-            and all pixels greater than one to one. </p>
-            <p>Select <i>%(NO)s</i> to
-            allow values less than zero and greater than one in the output
-            image.</p>""" % globals())
+                'Clip intensities to 0 and 1?', True, doc="""\
+*(Used only if "%(FIT_POLYNOMIAL)s" is selected)*
 
-        self.outlierneighbourhood = cps.Integer(
-            'Outlier neighbourhood', 3, 3, doc="""
-            <i> Used only if %(REMOVE_OUTLIER)s is selected)</i><br>
-            The %(REMOVE_OUTLIER)s module needs a radius that is considered
-            the neightbourhood of a pixel. Note that this needs to be an odd
-            number. If an even number is provided it is rounded up to the next
-            odd number.""" % globals())
+The *%(FIT_POLYNOMIAL)s* method is the only smoothing option that can
+yield an output image whose values are outside of the values of the
+input image. This setting controls whether to limit the image
+intensity to the 0 - 1 range used by CellProfiler.
 
-        self.threshold = cps.Float(
-                'Outlier Treshold', 50, 0, doc="""
-            <i> (Used only if %(REMOVE_OUTLIER)s is selected)</i><br>
-            The %(REMOVE_OUTLIER)s modules needs a threshold to consider
-            outliers. If the second heightest pixel of the neightbourhood is
-            larger than this threshold, the value is equal to the second
-            highest neightbour.
-            """ % globals())
+Select *%(YES)s* to set all output image pixels less than zero to zero
+and all pixels greater than one to one.
 
-        self.scale_threshold = cps.Binary(
-                'Scale Treshold to image scale?', True, doc="""
-            <i> (Used only if %(REMOVE_OUTLIER)s is selected)</i><br>
-            Should the threshold selected for %(REMOVE_OUTLIER)s be scaled
-            by the image scaling or be taken as-is?
-            In CellProfiler usually the image values are rescaled to 0-1.
-            Thus if the threshold should be selected based on the raw data values,
-            it needs to be scaled.
-            For example: If the image was Uint16 it is rescaled. Thus all values
-            are now divided by 2^16. If one wants now to set a threshold of 100 counts,
-            with scaling %(NO)s would need to set a threshold of 100/2^16=0.0015. With scaling
-            %(YES)s one would just set a threshold of 100.
-            """ % globals())
+Select *%(NO)s* to allow values less than zero and greater than one in
+the output image.
+""" % globals())
+
+        self.hp_filter_size = cps.Integer(
+                'Neighborhood filter size', 3, minval=3, doc="""\
+*(Used only if "%(CLIP_HOT_PIXELS)s" is selected)*)
+
+Enter the size of the local neighborhood filter (recommended value: 3). This
+value will be used to define the maximum distance around an individual pixel
+within which other pixels will be considered as neighboring pixels. Note that
+this value can be interpreted as diameter and thus has to be odd.
+""" % globals())
+
+        self.hp_threshold = cps.Float(
+                'Hot pixel threshold', 50, minval=0, doc="""\
+*(Used only if "%(CLIP_HOT_PIXELS)s" is selected)*)
+
+Enter the absolute threshold on the difference between the individual pixel
+intensity and it's maximum local neighbor intensity. This value will be used
+to identify "hot pixels" whose intensity values will be clipped to the maximum
+local neighbor intensity.
+""" % globals())
+
+        self.scale_hp_threshold = cps.Binary(
+                'Scale hot pixel threshold to image scale?', True, doc="""\
+*(Used only if "%(CLIP_HOT_PIXELS)s" is selected)*)
+
+Specify whether the hot pixel threshold should be scaled to the image scale or
+be taken as-is. In CellProfiler, the image values are usually rescaled to 0-1.
+Thus, if the threshold should be selected based on the raw data values, it
+needs to be scaled.
+
+Example: If the image data type was uint16, the image is rescaled automatically
+upon import. Thus all absolute values now have to be divided by 2^16. For
+example, if one wants to set a threshold of 100 counts, a value of either
+100 / 2^16 = 0.0015 (no scaling) or 100 (scaling) needs to be specified.
+""" % globals())
 
     def settings(self):
         return [self.image_name, self.filtered_image_name,
                 self.smoothing_method, self.wants_automatic_object_size,
                 self.object_size, self.sigma_range, self.clip,
-                self.outlierneighbourhood, self.threshold, self.scale_threshold]
+                self.hp_filter_size, self.hp_threshold,
+                self.scale_hp_threshold]
+
+    def upgrade_settings(self, setting_values, variable_revision_number,
+                         module_name, from_matlab):
+        if variable_revision_number < 2:
+            setting_values += [3 , 20]  # hp_filter_size, hp_threshold
+        if variable_revision_number < 3:
+            setting_values.append(False)  # scale_hp_threshold
+        return setting_values, variable_revision_number, from_matlab
 
     def visible_settings(self):
         result = [self.image_name, self.filtered_image_name,
                   self.smoothing_method]
-        if self.smoothing_method.value not in [FIT_POLYNOMIAL, SM_TO_AVERAGE,
-                                              REMOVE_OUTLIER]:
+        if self.smoothing_method.value not in [FIT_POLYNOMIAL, SM_TO_AVERAGE, CLIP_HOT_PIXELS]:
             result.append(self.wants_automatic_object_size)
             if not self.wants_automatic_object_size.value:
                 result.append(self.object_size)
@@ -175,148 +225,113 @@ class SmoothMultichannel(cpm.Module):
                 result.append(self.sigma_range)
         if self.smoothing_method.value == FIT_POLYNOMIAL:
             result.append(self.clip)
-        if self.smoothing_method.value == REMOVE_OUTLIER:
-            result.append(self.outlierneighbourhood)
-            result.append(self.threshold)
-            result.append(self.scale_threshold)
+        if self.smoothing_method.value == CLIP_HOT_PIXELS:
+            result.append(self.hp_filter_size)
+            result.append(self.hp_threshold)
+            result.append(self.scale_hp_threshold)
         return result
 
-    def run_per_layer(self, image, channel):
-        if channel >= 0:
-            pixel_data = image.pixel_data[:,:,channel].squeeze()
+    def run(self, workspace):
+        image = workspace.image_set.get_image(self.image_name.value,
+            must_be_grayscale=False)
+        hp_threshold = self.hp_threshold.value
+        if self.scale_hp_threshold.value is True:
+            hp_threshold /= image.scale
+        if len(image.pixel_data.shape) == 3:
+            if self.smoothing_method.value == CLIP_HOT_PIXELS:
+                # TODO support masks
+                hp_filter_shape = (self.hp_filter_size.value, self.hp_filter_size.value, 1)
+                output_pixels = SmoothMultichannel.clip_hot_pixels(image.pixel_data, hp_filter_shape, hp_threshold)
+            else:
+                output_pixels = image.pixel_data.copy()
+                for channel in range(image.pixel_data.shape[2]):
+                    output_pixels[:, :, i] = self.run_grayscale(image.pixel_data[:, :, i])
         else:
-            pixel_data = image.pixel_data
-        mask = image.mask
+            if self.smoothing_method.value == CLIP_HOT_PIXELS:
+                # TODO support masks
+                hp_filter_shape = (self.hp_filter_size.value, self.hp_filter_size.value)
+                output_pixels = SmoothMultichannel.clip_hot_pixels(image.pixel_data, hp_filter_shape, hp_threshold)
+            else:
+                output_pixels = self.run_grayscale(image.pixel_data)
+        output_image = cpi.Image(output_pixels, parent_image=image)
+        workspace.image_set.add(self.filtered_image_name.value, output_image)
+        workspace.display_data.pixel_data = image.pixel_data
+        workspace.display_data.output_pixels = output_pixels
+
+    def run_grayscale(self, image):
+        pixel_data = image.pixel_data
         if self.wants_automatic_object_size.value:
             object_size = min(30, max(1, np.mean(pixel_data.shape) / 40))
         else:
             object_size = float(self.object_size.value)
         sigma = object_size / 2.35
-
         if self.smoothing_method.value == GAUSSIAN_FILTER:
             def fn(image):
                 return scind.gaussian_filter(image, sigma,
                                              mode='constant', cval=0)
 
             output_pixels = smooth_with_function_and_mask(pixel_data, fn,
-                                                          mask)
+                                                          image.mask)
         elif self.smoothing_method.value == MEDIAN_FILTER:
-            output_pixels = median_filter(pixel_data, mask,
+            output_pixels = median_filter(pixel_data, image.mask,
                                           object_size / 2 + 1)
         elif self.smoothing_method.value == SMOOTH_KEEPING_EDGES:
             sigma_range = float(self.sigma_range.value)
-            output_pixels = bilateral_filter(pixel_data, mask,
-                                             sigma, sigma_range)
+
+            output_pixels = skimage.restoration.denoise_bilateral(
+                image=pixel_data,
+                multichannel=image.multichannel,
+                sigma_color=sigma_range,
+                sigma_spatial=sigma
+            )
         elif self.smoothing_method.value == FIT_POLYNOMIAL:
-            output_pixels = fit_polynomial(pixel_data, mask,
+            output_pixels = fit_polynomial(pixel_data, image.mask,
                                            self.clip.value)
         elif self.smoothing_method.value == CIRCULAR_AVERAGE_FILTER:
-            output_pixels = circular_average_filter(pixel_data,
-                                                    object_size / 2 + 1, mask)
+            output_pixels = circular_average_filter(pixel_data, object_size / 2 + 1, image.mask)
         elif self.smoothing_method.value == SM_TO_AVERAGE:
             if image.has_mask:
-                mean = np.mean(pixel_data[mask])
+                mean = np.mean(pixel_data[image.mask])
             else:
                 mean = np.mean(pixel_data)
-                output_pixels = np.ones(pixel_data.shape, pixel_data.dtype) * mean
-
-        elif self.smoothing_method.value == REMOVE_OUTLIER:
-            # TODO: implement how this deals with masks.
-            nbhood = self.outlierneighbourhood.value
-            threshold = self.threshold.value
-            if self.scale_threshold.value:
-                threshold= threshold / image.scale
-            output_pixels = self.remove_outlier_pixels(pixel_data,
-                                                         threshold=threshold,
-                                                         radius=nbhood,
-                                                         mode='max')
+            output_pixels = np.ones(pixel_data.shape, pixel_data.dtype) * mean
         else:
             raise ValueError("Unsupported smoothing method: %s" %
                              self.smoothing_method.value)
-
         return output_pixels
 
-    def run(self, workspace):
-        image = workspace.image_set.get_image(self.image_name.value,
-                                              must_be_grayscale=False)
-
-        output_pixels =image.pixel_data.copy()
-
-        if len(image.pixel_data.shape) ==3:
-            for i in range(image.pixel_data.shape[2]):
-                output_pixels[:,:,i] = self.run_per_layer(image, i)
-        else:
-            output_pixels = self.run_per_layer(image, -1)
-
-        output_image = cpi.Image(output_pixels, parent_image=image)
-        workspace.image_set.add(self.filtered_image_name.value,
-                                output_image)
-        workspace.display_data.pixel_data = image.pixel_data
-        workspace.display_data.output_pixels = output_pixels
-
     def display(self, workspace, figure):
-        figure.set_subplots((2, 1))
-
-        img_orig = workspace.display_data.pixel_data
-        img_filt = workspace.display_data.output_pixels
-        #if len(img_orig.shape) > 2:
-        #    img_orig = img_orig[:,:,0]
-        #    img_filt = img_filt[:,:,0]
-
-        ax1 = figure.subplot_imshow_color(0, 0,
-                                        workspace.display_data.pixel_data,
-                                        "Original: %s" %
-                                        self.image_name.value)
-        ax2 = figure.subplot_imshow_color(1, 0,
-                                        workspace.display_data.output_pixels,
-                                        "Filtered: %s" %
-                                        self.filtered_image_name.value,
+        figure.set_subplots((2, 2))
+        original = workspace.display_data.pixel_data
+        if len(original.shape) == 3:
+            original = np.sum(original / original.shape[2], axis=2)
+        figure.subplot_imshow_grayscale(0, 0,
+                                        original,
+                                        "Original: %s" % self.image_name.value)
+        filtered = workspace.display_data.output_pixels
+        if len(filtered.shape) == 3:
+            filtered = np.sum(filtered / filtered.shape[2], axis=2)
+        figure.subplot_imshow_grayscale(1, 0,
+                                        filtered,
+                                        "Filtered: %s" % self.filtered_image_name.value,
                                         sharexy=figure.subplot(0, 0))
-        # import pdb; pdb.set_trace()
-        #schan1 = Slider(ax1, 'channel 1', 0, nchannel1,  valinit=1)
-        #schan2 = Slider(ax2, 'channel 2', 0, nchannel2, valinit=1)
+        difference = workspace.display_data.pixel_data - workspace.display_data.output_pixels
+        if len(difference.shape) == 3:
+            difference = np.sum(difference / difference.shape[2], axis=2)
+        figure.subplot_imshow_grayscale(0, 1,
+                                        difference,
+                                        "Difference: original - filtered",
+                                        sharexy=figure.subplot(0, 0))
 
-        # def update(val):
-        #     channel1 = schan1.val
-        #     channel2 = schan2.val
-        #
-        # schan1.on_changed(update)
-        # schan2.on_changed(update)
-
-    def upgrade_settings(self, setting_values, variable_revision_number,
-                         module_name, from_matlab):
-        if variable_revision_number < 2:
-            setting_values += [3 , # outlier neighbourhood
-                             20]  # threshold
-        if variable_revision_number < 4:
-            setting_values += [cps.NO]
-        return setting_values, variable_revision_number, from_matlab
-
-
-    # function
     @staticmethod
-    def remove_outlier_pixels(img, threshold=50, mode='median', radius=3):
-        """
+    def clip_hot_pixels(img, hp_filter_shape, hp_threshold):
+        if hp_filter_shape[0] % 2 != 1 or hp_filter_shape[1] % 2 != 1:
+            raise ValueError("Invalid hot pixel filter shape: %s" % str(hp_filter_shape))
+        hp_filter_footprint = np.ones(hp_filter_shape)
+        hp_filter_footprint[int(hp_filter_shape[0] / 2), int(hp_filter_shape[1] / 2)] = 0
+        max_img = scind.maximum_filter(img, footprint=hp_filter_footprint, mode='reflect')
+        hp_mask = img - max_img > hp_threshold
+        img = img.copy()
+        img[hp_mask] = max_img[hp_mask]
+        return img
 
-        >>> a = np.zeros((10, 10))
-        >>> b = a.copy()
-        >>> b[5,5] = 100
-        >>> np.all(a == remove_outlier_pixels(b, threshold=50, mode='max',\
-                                              radius=3))
-        True
-        """
-        if (radius % 2) == 0:
-           radius += 1
-        mask = np.ones((radius, radius))
-        mask[int((radius-1)/2),int((radius-1)/2)] = 0
-
-        if mode == 'max':
-            img_agg = ndi.filters.maximum_filter(img, footprint=mask)
-        elif mode == 'median':
-            img_agg = ndi.generic_filter(img, np.median, footprint=mask)
-        else:
-            raise('Mode must be: max or median')
-        img_out = img.copy()
-        imgfil = (img-img_agg) > threshold
-        img_out[imgfil] = img_agg[imgfil]
-        return img_out

--- a/tests/test_smoothmultichannel.py
+++ b/tests/test_smoothmultichannel.py
@@ -1,0 +1,267 @@
+'''test_smooth.py - test the smooth module
+'''
+
+import StringIO
+import base64
+import unittest
+import zlib
+
+import numpy as np
+from scipy.ndimage import gaussian_filter
+
+from cellprofiler.preferences import set_headless
+
+set_headless()
+
+import cellprofiler.workspace as cpw
+import cellprofiler.image as cpi
+import cellprofiler.module as cpm
+import cellprofiler.modules as modules
+import cellprofiler.object as cpo
+import cellprofiler.pipeline as cpp
+import cellprofiler.measurement as cpmeas
+from centrosome.smooth import fit_polynomial, smooth_with_function_and_mask
+from centrosome.filter import median_filter, bilateral_filter
+import skimage.restoration
+
+import plugins.smoothmultichannel as S
+
+INPUT_IMAGE_NAME = 'myimage'
+OUTPUT_IMAGE_NAME = 'myfilteredimage'
+
+
+class TestSmooth(unittest.TestCase):
+    def make_workspace(self, image, mask):
+        '''Make a workspace for testing FilterByObjectMeasurement'''
+        module = S.SmoothMultichannel()
+        pipeline = cpp.Pipeline()
+        object_set = cpo.ObjectSet()
+        image_set_list = cpi.ImageSetList()
+        image_set = image_set_list.get_image_set(0)
+        workspace = cpw.Workspace(pipeline,
+                                  module,
+                                  image_set,
+                                  object_set,
+                                  cpmeas.Measurements(),
+                                  image_set_list)
+        image_set.add(INPUT_IMAGE_NAME, cpi.Image(image, mask,
+                                                  scale=1))
+        module.image_name.value = INPUT_IMAGE_NAME
+        module.filtered_image_name.value = OUTPUT_IMAGE_NAME
+        return workspace, module
+
+    def test_01_01_load_matlab(self):
+        data = base64.b64decode(
+                'TUFUTEFCIDUuMCBNQVQtZmlsZSwgUGxhdGZvcm06IFBDV0lOLCBDcmVhdGVkIG9u'
+                'OiBGcmkgTWF5IDA4IDE0OjU1OjE0IDIwMDkgICAgICAgICAgICAgICAgICAgICAg'
+                'ICAgICAgICAgICAgICAgICAgICAgICAgICAgIAABSU0PAAAAAgIAAHic3VW7TsMw'
+                'FL0NKRSEymNiYMjIQmmFhBh5i0rQVhQhIbGY1KSWErtKHNQiPoCRz2Hk07AhaRNT'
+                'yIOoA46s6Dr3nHtzfOJUAeB1GWBe3CtiavA1ykFcikwZdzHnhFpeGXTYCNbfxbxB'
+                'LkH3Nr5Bto89GI9wvUkf2PVoMH50yXq+jVvIiSaL0fKde+x67YcQGDzukCG2u+QJ'
+                'Q3yEaVf4kXiE0QAf8Kur47qMK3WrYm4sTHQoKTpIXdYj6zL/ACb5+hTdViP5q8G8'
+                'xkO+fTpEJjccxM2+5NlP4KkoPDJuu8Q6ElJLfD0Br8fwOpwcdpp56x4z1w3r/rXv'
+                'JP2qCl7GZ4QbHWaPKHMIstPtw5LCI+MTZlDGDd8LDJWGZ1HhkfGhz5nYSGJCep6i'
+                '+pk1T5LPtBiPBi022/qqzxt7tfos68/FeOagXmsU+v5p+yjF+Eqwq+CL7uc8gW9N'
+                '4ZMxoT3ySHo+sg3iIGt8Gmd5z5/8llenWkadpp0HlotGnolsHOFJ24/qn1uhyiz1'
+                'UOvTHRTD72u//x+jevzVb5+msFzmD7LzTfvvTvgMYT08KJJH7a/oPv8L/xv87B/V'
+                'v3l9c8FQrxk5UNLwrCg8Mu46jPF+2z2lfURN/O37mU/oXxPXeiXfOdSA77g09crl'
+                '7DhdXHebz5sS9wLZ9mfrl/xw5M3/AOjFxSA=')
+        pipeline = cpp.Pipeline()
+        pipeline.load(StringIO.StringIO(data))
+        self.assertEqual(len(pipeline.modules()), 2)
+        smooth = pipeline.modules()[1]
+        self.assertEqual(smooth.module_name, 'Smooth')
+        self.assertEqual(smooth.image_name.value, 'OrigBlue')
+        self.assertEqual(smooth.filtered_image_name.value, 'CorrBlue')
+        self.assertEqual(smooth.smoothing_method.value, S.FIT_POLYNOMIAL)
+        self.assertTrue(smooth.wants_automatic_object_size)
+
+    def test_01_02_load_v01(self):
+        data = base64.b64decode(
+                'eJztWN1u0zAUdrqsbCDt5wourV0hxKJ0iGr0hnUrE5GWrqLVBHd4rdtZcuLKcaaWJ'
+                '+CSR+JxuNwjEJekSUxo0mxMqlRXlnvs853P57MT17WbvYvmKXxrmNBu9g6HhGLYoU'
+                'gMGXca0BWv4RnHSOABZG4DnnMCbTSF5jGs1RtmvVE7gkem+Q6UK5pl7wTNj30AqkG'
+                '7FdRKOLQZ2lqiSruLhSDuyNsEOngR9v8M6hXiBF1TfIWoj72YIuq33CHrTcfzIZsN'
+                'fIrbyEk6B6XtO9eYe5fDCBgOd8gE0y75hpUUIrdP+JZ4hLkhPoyv9s55mVB4pQ7mk'
+                '1gHTdFB6rKb6Jf+H0Hsr2fotp/w3wtt4g7ILRn4iELioNF8FjLecU68LSWetC85GZ'
+                '0Gkkv8SQ5+T8HL2sMTcfhhgvoCOkj0b8rO44xxHs3DzMFrKbwG3oT5581/R+GV9jk'
+                'RsMPo1GUOQbRYnKdKHGm3GHSZgL6H4/XIy2MjFWcDfAlWswiuksJVQJsV49NTOB3U'
+                '6oZZZB8+V/KVdgsPkU8FtOQmhC3CcV8wPi2Vt2nUCuHUdTcydK4quKhEuO2wfSidV'
+                '5lP3Q+tZse6D9993z+rkueyfG3mPmp+q8b3q7rcuVmW5yQnr6z3+uyQHXHmj/8/f9'
+                'b5GvPD4OjH44da1zVujVvj1s/xGvf4uLsETj3v1N+B0v8rWLzfXoH0fpN2H1M65kz'
+                '+H8ANZ3Zp9QzK0ODPrdG4CL5aiQuk5Pmcw3Og8Bz8i8dzGBM3RnfWZOu1nRE/mXcl'
+                '+OxWF+us6hvrfve+DF9F+5vvWQ5OD5WSuO9guXV9ucA/yq2s/29KodH7')
+        data = zlib.decompress(data)
+        pipeline = cpp.Pipeline()
+        pipeline.load(StringIO.StringIO(data))
+        self.assertEqual(len(pipeline.modules()), 2)
+        smooth = pipeline.modules()[1]
+        self.assertEqual(smooth.module_name, 'Smooth')
+        self.assertEqual(smooth.image_name.value, 'OrigBlue')
+        self.assertEqual(smooth.filtered_image_name.value, 'CorrBlue')
+        self.assertEqual(smooth.smoothing_method.value, S.FIT_POLYNOMIAL)
+        self.assertTrue(smooth.wants_automatic_object_size)
+        self.assertTrue(smooth.clip)
+
+    def test_01_03_load_v02(self):
+        data = r"""CellProfiler Pipeline: http://www.cellprofiler.org
+Version:3
+DateRevision:20130522170932
+ModuleCount:1
+HasImagePlaneDetails:False
+
+SmoothMultichannel:[module_num:1|svn_version:\'Unknown\'|variable_revision_number:2|show_window:False|notes:\x5B\x5D|batch_state:array(\x5B\x5D, dtype=uint8)|enabled:True]
+    Select the input image:InputImage
+    Name the output image:OutputImage
+    Select smoothing method:Median Filter
+    Calculate artifact diameter automatically?:Yes
+    Typical artifact diameter, in  pixels:19.0
+    Edge intensity difference:0.2
+    Clip intensity at 0 and 1:No
+
+"""
+        pipeline = cpp.Pipeline()
+        modules.add_module_for_tst(S.SmoothMultichannel)
+        pipeline.load(StringIO.StringIO(data))
+        self.assertEqual(len(pipeline.modules()), 1)
+        smooth = pipeline.modules()[0]
+        self.assertTrue(isinstance(smooth, S.SmoothMultichannel))
+        self.assertEqual(smooth.image_name, "InputImage")
+        self.assertEqual(smooth.filtered_image_name, "OutputImage")
+        self.assertTrue(smooth.wants_automatic_object_size)
+        self.assertEqual(smooth.object_size, 19)
+        self.assertEqual(smooth.smoothing_method, S.MEDIAN_FILTER)
+        self.assertFalse(smooth.clip)
+
+    def test_02_01_fit_polynomial(self):
+        '''Test the smooth module with polynomial fitting'''
+        np.random.seed(0)
+        #
+        # Make an image that has a single sinusoidal cycle with different
+        # phase in i and j. Make it a little out-of-bounds to start to test
+        # clipping
+        #
+        i, j = np.mgrid[0:100, 0:100].astype(float) * np.pi / 50
+        image = (np.sin(i) + np.cos(j)) / 1.8 + .9
+        image += np.random.uniform(size=(100, 100)) * .1
+        mask = np.ones(image.shape, bool)
+        mask[40:60, 45:65] = False
+        for clip in (False, True):
+            expected = fit_polynomial(image, mask, clip)
+            self.assertEqual(np.all((expected >= 0) & (expected <= 1)), clip)
+            workspace, module = self.make_workspace(image, mask)
+            module.smoothing_method.value = S.FIT_POLYNOMIAL
+            module.clip.value = clip
+            module.run(workspace)
+            result = workspace.image_set.get_image(OUTPUT_IMAGE_NAME)
+            self.assertFalse(result is None)
+            np.testing.assert_almost_equal(result.pixel_data, expected)
+
+    def test_03_01_gaussian_auto_small(self):
+        '''Test the smooth module with Gaussian smoothing in automatic mode'''
+        sigma = 100.0 / 40.0 / 2.35
+        np.random.seed(0)
+        image = np.random.uniform(size=(100, 100)).astype(np.float32)
+        mask = np.ones(image.shape, bool)
+        mask[40:60, 45:65] = False
+        fn = lambda x: gaussian_filter(x, sigma, mode='constant', cval=0.0)
+        expected = smooth_with_function_and_mask(image, fn, mask)
+        workspace, module = self.make_workspace(image, mask)
+        module.smoothing_method.value = S.GAUSSIAN_FILTER
+        module.run(workspace)
+        result = workspace.image_set.get_image(OUTPUT_IMAGE_NAME)
+        self.assertFalse(result is None)
+        np.testing.assert_almost_equal(result.pixel_data, expected)
+
+    def test_03_02_gaussian_auto_large(self):
+        '''Test the smooth module with Gaussian smoothing in large automatic mode'''
+        sigma = 30.0 / 2.35
+        image = np.random.uniform(size=(3200, 100)).astype(np.float32)
+        mask = np.ones(image.shape, bool)
+        mask[40:60, 45:65] = False
+        fn = lambda x: gaussian_filter(x, sigma, mode='constant', cval=0.0)
+        expected = smooth_with_function_and_mask(image, fn, mask)
+        workspace, module = self.make_workspace(image, mask)
+        module.smoothing_method.value = S.GAUSSIAN_FILTER
+        module.run(workspace)
+        result = workspace.image_set.get_image(OUTPUT_IMAGE_NAME)
+        self.assertFalse(result is None)
+        np.testing.assert_almost_equal(result.pixel_data, expected)
+
+    def test_03_03_gaussian_manual(self):
+        '''Test the smooth module with Gaussian smoothing, manual sigma'''
+        sigma = 15.0 / 2.35
+        np.random.seed(0)
+        image = np.random.uniform(size=(100, 100)).astype(np.float32)
+        mask = np.ones(image.shape, bool)
+        mask[40:60, 45:65] = False
+        fn = lambda x: gaussian_filter(x, sigma, mode='constant', cval=0.0)
+        expected = smooth_with_function_and_mask(image, fn, mask)
+        workspace, module = self.make_workspace(image, mask)
+        module.smoothing_method.value = S.GAUSSIAN_FILTER
+        module.wants_automatic_object_size.value = False
+        module.object_size.value = 15.0
+        module.run(workspace)
+        result = workspace.image_set.get_image(OUTPUT_IMAGE_NAME)
+        self.assertFalse(result is None)
+        np.testing.assert_almost_equal(result.pixel_data, expected)
+
+    def test_04_01_median(self):
+        '''test the smooth module with median filtering'''
+        object_size = 100.0 / 40.0
+        np.random.seed(0)
+        image = np.random.uniform(size=(100, 100)).astype(np.float32)
+        mask = np.ones(image.shape, bool)
+        mask[40:60, 45:65] = False
+        expected = median_filter(image, mask, object_size / 2 + 1)
+        workspace, module = self.make_workspace(image, mask)
+        module.smoothing_method.value = S.MEDIAN_FILTER
+        module.run(workspace)
+        result = workspace.image_set.get_image(OUTPUT_IMAGE_NAME)
+        self.assertFalse(result is None)
+        np.testing.assert_almost_equal(result.pixel_data, expected)
+
+    def test_05_01_bilateral(self):
+        '''test the smooth module with bilateral filtering'''
+        sigma = 16.0
+        sigma_range = .2
+        np.random.seed(0)
+        image = np.random.uniform(size=(100, 100)).astype(np.float32)
+        mask = np.ones(image.shape, bool)
+        mask[40:60, 45:65] = False
+        expected = skimage.restoration.denoise_bilateral(
+            image=image,
+            multichannel=False,
+            sigma_color=sigma_range,
+            sigma_spatial=sigma,
+        )
+        workspace, module = self.make_workspace(image, mask)
+        module.smoothing_method.value = S.SMOOTH_KEEPING_EDGES
+        module.sigma_range.value = sigma_range
+        module.wants_automatic_object_size.value = False
+        module.object_size.value = 16.0 * 2.35
+        module.run(workspace)
+        result = workspace.image_set.get_image(OUTPUT_IMAGE_NAME)
+        self.assertFalse(result is None)
+        np.testing.assert_almost_equal(result.pixel_data, expected)
+
+    def test_06_01_remove_outlier(self):
+        ''' Test the smooth module for outlier filtering
+            Test if a singe outlier pixel will be detected.
+        '''
+        img_shape = (10, 10)
+        image = np.zeros(img_shape)
+        image[5,5] = 1
+
+        mask = np.ones(img_shape)
+        expected_image = np.zeros(img_shape)
+
+        workspace, module = self.make_workspace(image, mask)
+        module.smoothing_method.value = S.CLIP_HOT_PIXELS
+        module.hp_threshold.value=0.1
+        module.hp_filter_size.value=3
+        module.scale_hp_threshold.value = False
+        module.run(workspace)
+        result = workspace.image_set.get_image(OUTPUT_IMAGE_NAME)
+        np.testing.assert_almost_equal(result.pixel_data, expected_image)
+

--- a/tests/test_smoothmultichannel.py
+++ b/tests/test_smoothmultichannel.py
@@ -110,7 +110,7 @@ DateRevision:20130522170932
 ModuleCount:1
 HasImagePlaneDetails:False
 
-SmoothMultichannel:[module_num:1|svn_version:\'Unknown\'|variable_revision_number:2|show_window:False|notes:\x5B\x5D|batch_state:array(\x5B\x5D, dtype=uint8)|enabled:True]
+Smooth Multichannel:[module_num:1|svn_version:\'Unknown\'|variable_revision_number:2|show_window:False|notes:\x5B\x5D|batch_state:array(\x5B\x5D, dtype=uint8)|enabled:True]
     Select the input image:InputImage
     Name the output image:OutputImage
     Select smoothing method:Median Filter


### PR DESCRIPTION
This adds the option in the 'smoothmultichannel' module in the `removeoutlier` function to scale the threshold the same way as the image was scaled during loading. Enabling this allows to set a threshold corresponding to the input image scale, which could correspond e.g. to detector counts and thus be meaningful.

Additionally I noticed that the `removeoutlier` function was using a rather inefficient function to do the max-filtering. Thus I switched them out.