### PR TITLE
StackImages module

### DIFF
--- a/plugins/stackimages.py
+++ b/plugins/stackimages.py
@@ -24,7 +24,7 @@ import cellprofiler.image as cpi
 import cellprofiler.module as cpm
 import cellprofiler.setting as cps
 
-SCHEME_COMPOSITE = "Composite"
+OFF_STACK_CHANNEL_COUNT = 1
 
 class StackImages(cpm.Module):
     module_name = 'StackImages'
@@ -70,10 +70,9 @@ Select the input image to add to the stacked image.
         return result
 
     def prepare_settings(self, setting_values):
-        try:
-            num_stack_images = int(setting_values[OFF_STACK_CHANNEL_COUNT])
-        except ValueError:
-            num_stack_images = 1
+        num_stack_images = int(setting_values[OFF_STACK_CHANNEL_COUNT])
+        # Why is the following needed? Taken over from graytocolor but
+        # I do not see that this would be actually needed...
         del self.stack_channels[num_stack_images:]
         while len(self.stack_channels) < num_stack_images:
             self.add_stack_channel_cb()

--- a/plugins/stackimages.py
+++ b/plugins/stackimages.py
@@ -1,0 +1,159 @@
+# coding=utf-8
+
+"""
+Stackimages
+===========
+TODO: Improve documentation
+**StackImages** takes a grayscale or color images and stacks them.
+
+============ ============ ===============
+Supports 2D? Supports 3D? Respects masks?
+============ ============ ===============
+YES          NO           NO
+============ ============ ===============
+
+See also
+^^^^^^^^
+
+See also **ColorToGray** and **GrayToColor**.
+"""
+# This is almost 1:1 copied from GrayToColor from CellProfiler
+import numpy as np
+
+import cellprofiler.image as cpi
+import cellprofiler.module as cpm
+import cellprofiler.setting as cps
+
+SCHEME_COMPOSITE = "Composite"
+
+class StackImages(cpm.Module):
+    module_name = 'StackImages'
+    variable_revision_number = 1
+    category = "Image Processing"
+
+    def create_settings(self):
+
+        # # # # # # # # # # # # # #
+        #
+        # Stack settings
+        #
+        # # # # # # # # # # # # # #
+        self.stack_image_name = cps.ImageNameProvider(
+                "Name the output image", "ColorImage", doc="""Enter a name for the resulting image.""")
+
+        self.stack_channels = []
+        self.stack_channel_count = cps.HiddenCount(self.stack_channels)
+        self.add_stack_channel_cb(can_remove=False)
+        self.add_stack_channel_cb(can_remove=False)
+        self.add_stack_channel = cps.DoSomething("Add another channel", "Add another channel", self.add_stack_channel_cb,
+        doc="""\
+    Press this button to add another image to the stack.
+    """)
+
+    def add_stack_channel_cb(self, can_remove=True):
+        group = cps.SettingsGroup()
+        group.append("image_name", cps.ImageNameSubscriber(
+                "Image name", cps.NONE,
+                doc='''\
+Select the input image to add to the stacked image.
+''' % globals()))
+
+        if can_remove:
+            group.append("remover", cps.RemoveSettingButton("", "Remove this image", self.stack_channels, group))
+        self.stack_channels.append(group)
+
+    def settings(self):
+        result = [self.stack_image_name,
+                self.stack_channel_count]
+        for stack_channel in self.stack_channels:
+            result += [stack_channel.image_name]
+        return result
+
+    def prepare_settings(self, setting_values):
+        try:
+            num_stack_images = int(setting_values[OFF_STACK_CHANNEL_COUNT])
+        except ValueError:
+            num_stack_images = 1
+        del self.stack_channels[num_stack_images:]
+        while len(self.stack_channels) < num_stack_images:
+            self.add_stack_channel_cb()
+
+    def visible_settings(self):
+        result = [self.stack_image_name]
+        for sc_group in self.stack_channels:
+            result.append(sc_group.image_name)
+            if hasattr(sc_group, "remover"):
+                result.append(sc_group.remover)
+        result += [self.add_stack_channel]
+        return result
+
+    def validate_module(self, pipeline):
+        """
+        nothing to do at the moment
+        """
+        pass
+
+    def run(self, workspace):
+        parent_image = None
+        parent_image_name = None
+        imgset = workspace.image_set
+        stack_pixel_data = None
+        input_image_names = []
+        channel_names = []
+        input_image_names = [sc.image_name.value for sc in self.stack_channels]
+        channel_names = input_image_names
+        source_channels = [imgset.get_image(name, must_be_grayscale=False).pixel_data
+                           for name in input_image_names]
+        parent_image = imgset.get_image(input_image_names[0])
+        for idx, pd in enumerate(source_channels):
+            if pd.shape[:2] != source_channels[0].shape[:2]:
+                raise ValueError("The %s image and %s image have different sizes (%s vs %s)" %
+                                 (self.stack_channels[0].image_name.value,
+                                  self.stack_channels[idx].image_name.value,
+                                  source_channels[0].shape[:2],
+                                  pd.pixel_data.shape[:2]))
+        stack_pixel_data = np.dstack(source_channels)
+
+        ##############
+        # Save image #
+        ##############
+        stack_image = cpi.Image(stack_pixel_data, parent_image=parent_image)
+        stack_image.channel_names = channel_names
+        imgset.add(self.stack_image_name.value, stack_image)
+
+        ##################
+        # Display images #
+        ##################
+        if self.show_window:
+            workspace.display_data.input_image_names = input_image_names
+            workspace.display_data.stack_pixel_data = stack_pixel_data
+            workspace.display_data.images = \
+                [imgset.get_image(name, must_be_grayscale=False).pixel_data
+                 for name in input_image_names]
+
+    def display(self, workspace, figure):
+        # TODO: do a meaningfull display
+        input_image_names = workspace.display_data.input_image_names
+        images = workspace.display_data.images
+        nsubplots = len(input_image_names)
+        subplots = (min(nsubplots + 1, 4), int(nsubplots / 4) + 1)
+        subplot_indices = [(i % 4, int(i / 4)) for i in range(nsubplots)]
+        color_subplot = (nsubplots % 4, int(nsubplots / 4))
+        figure.set_subplots(subplots)
+        for i, (input_image_name, image_pixel_data) in \
+                enumerate(zip(input_image_names, images)):
+            x, y = subplot_indices[i]
+            #figure.subplot_imshow_grayscale(x, y, image_pixel_data,
+            #                                title=input_image_name,
+            #                                sharexy=figure.subplot(0, 0))
+            #figure.subplot(x, y).set_visible(True)
+        for x, y in subplot_indices[len(input_image_names):]:
+            figure.subplot(x, y).set_visible(False)
+        # figure.subplot_imshow(color_subplot[0], color_subplot[1],
+        #                      workspace.display_data.stack_pixel_data[:, :, :3],
+        #                      title=self.stack_image_name.value,
+        #                      sharexy=figure.subplot(0, 0))
+
+    def upgrade_settings(self, setting_values, variable_revision_number,
+                         module_name, from_matlab):
+        return setting_values, variable_revision_number, from_matlab

--- a/tests/test_stackimages.py
+++ b/tests/test_stackimages.py
@@ -1,0 +1,137 @@
+'''test_stackimages.py - test the stackimages module
+'''
+
+import StringIO
+import base64
+import unittest
+import zlib
+
+import numpy as np
+from scipy.ndimage import gaussian_filter
+
+from cellprofiler.preferences import set_headless
+
+set_headless()
+
+import cellprofiler.workspace as cpw
+import cellprofiler.image as cpi
+import cellprofiler.module as cpm
+import cellprofiler.modules as modules
+import cellprofiler.object as cpo
+import cellprofiler.pipeline as cpp
+import cellprofiler.measurement as cpmeas
+
+import plugins.stackimages as S
+
+INPUT_IMAGE_BASENAME = 'myimage'
+
+OUTPUT_IMAGE_NAME = 'mystackedimage'
+
+
+class TestStackImages(unittest.TestCase):
+    def make_workspace(self, images):
+        '''Make a workspace '''
+        module = S.StackImages()
+        pipeline = cpp.Pipeline()
+        object_set = cpo.ObjectSet()
+        image_set_list = cpi.ImageSetList()
+        image_set = image_set_list.get_image_set(0)
+        workspace = cpw.Workspace(pipeline,
+                                  module,
+                                  image_set,
+                                  object_set,
+                                  cpmeas.Measurements(),
+                                  image_set_list)
+
+        # setup the input images
+        names = [ INPUT_IMAGE_BASENAME+str(i) for i, img in enumerate(images) ]
+        for img, nam in zip(images, names):
+            image_set.add(nam, cpi.Image(img))
+
+        # setup the input images settings
+        module.stack_image_name.value = OUTPUT_IMAGE_NAME
+        nimgs = len(images)
+        while len(module.stack_channels) < nimgs:
+            module.add_stack_channel_cb()
+        for sc, imname in zip(module.stack_channels, names):
+            sc.image_name.value = imname
+
+        return workspace, module
+
+    def assert_stack(self, images, result):
+        # test if this is equal to the stacked images
+        lb = 0
+        for im in images:
+            if len(im.shape) > 2:
+                offset = im.shape[2]
+            else:
+                offset = 1
+            ub = lb+offset
+            np.testing.assert_equal(
+                    np.squeeze(result.pixel_data[:,:,lb:ub]), im)
+            lb = ub
+
+    def assert_shape(self, images, result):
+        new_shape = list(images[0].shape)[:2]
+        c = 0
+        for im in images:
+            if len(im.shape) > 2:
+                c += im.shape[2]
+            else:
+                c += 1
+        new_shape += [c]
+        np.testing.assert_equal(result.pixel_data.shape,
+                new_shape)
+
+    def test_stack_multichannel(self):
+        img_shape = (10, 10,5)
+        image1 = np.zeros(img_shape)
+        image2 = np.copy(image1)
+        image2[:] = 1
+        input_imgs =[image1, image2]
+        workspace, module = self.make_workspace(input_imgs)
+        module.run(workspace)
+        result = workspace.image_set.get_image(OUTPUT_IMAGE_NAME)
+        self.assert_stack(input_imgs, result)
+        self.assert_shape(input_imgs, result)
+
+
+    def test_stack_multi_gray(self):
+        img_shape = (10,10,5)
+        image1 = np.zeros(img_shape)
+        image1[:] = 1
+        img_shape2= (10,10)
+        image2 = np.zeros(img_shape2)
+        input_imgs =[image1, image2]
+        workspace, module = self.make_workspace(input_imgs)
+        module.run(workspace)
+        result = workspace.image_set.get_image(OUTPUT_IMAGE_NAME)
+        self.assert_stack(input_imgs, result)
+        self.assert_shape(input_imgs, result)
+
+    def test_stack_gray(self):
+        img_shape = (10, 10)
+        image1 = np.zeros(img_shape)
+        image2 = np.copy(image1)
+        image2[:] = 1
+        input_imgs =[image1, image2]
+        workspace, module = self.make_workspace(input_imgs)
+        module.run(workspace)
+        result = workspace.image_set.get_image(OUTPUT_IMAGE_NAME)
+        self.assert_stack(input_imgs, result)
+        self.assert_shape(input_imgs, result)
+
+    def test_stack_3multichannel(self):
+        nimgs = 5
+        img_shape = (10, 10,5)
+        image = np.zeros(img_shape)
+        input_imgs = []
+        for i in range(nimgs):
+            img = np.copy(image)
+            img[:] = i
+            input_imgs.append(img)
+        workspace, module = self.make_workspace(input_imgs)
+        module.run(workspace)
+        result = workspace.image_set.get_image(OUTPUT_IMAGE_NAME)
+        self.assert_stack(input_imgs, result)
+        self.assert_shape(input_imgs, result)


### PR DESCRIPTION
This adds a module that allows stacking of multiple multichannel/grayscale images together to form a new multichannel image.

This module also comes with tests and was also manually tested with the GUI (cellprofiler 3.1.5).

This allows more flexible stack processing, for example appending the mean intensity of a stack to a stack in combination with the SummarizeStack module.

This will allow us to simplify/streamline the processing, e.g. by deprecating the 'addsum' argument form `ometiff2analysis` (https://github.com/BodenmillerGroup/imctools/blob/fbe2474c254f71e1ccb96c202c81a168a54379b6/imctools/scripts/ometiff2analysis.py#L9), finally moving all the image processing operations out of `imctools` into preprocessing Cellprofiler pipelines.
