### PR TITLE
Fix docstring bug

### DIFF
--- a/plugins/measureimageintensitymultichannel.py
+++ b/plugins/measureimageintensitymultichannel.py
@@ -19,7 +19,7 @@ MeasureImageIntensityMultichannel
 **MeasureImageIntensity Multichannel ** measures several intensity features across an
 entire image over multiple channels (excluding masked pixels).
 
-The name of the measurements will have a suffix `_c{channelnr}` where channelnr is 1 based index of the plane.
+The name of the measurements will have a suffix `_c[channelnr]` where channelnr is 1 based index of the plane.
 
 For example, this module will sum all pixel values to measure the total image
 intensity. You can choose to measure all pixels in the image or restrict

--- a/plugins/measureobjectintensitymultichannel.py
+++ b/plugins/measureobjectintensitymultichannel.py
@@ -25,7 +25,7 @@ MeasureObjectIntensityMultichannel
 **MeasureObjectIntensity** measures several intensity features for
 identified objects for each plane of an entire image over multiple channels (excluding masked pixels).
 
-The name of the measurements will have a suffix `_c{channelnr}` where channelnr is 1 based index of the plane.
+The name of the measurements will have a suffix `_c[channelnr] ` where channelnr is 1 based index of the plane.
 
 Given an image with objects identified (e.g., nuclei or cells), this
 module extracts intensity features for each object based on one or more


### PR DESCRIPTION
Changed curly brakes to rectangular ones to prevent format error in docstring. 